### PR TITLE
Explicitly set locale after signin and account update

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,10 +12,11 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def set_locale
-    if current_user.present?
+  def set_locale(user = nil)
+    user ||= current_user
+    if user.present?
       begin
-        I18n.locale = ISO_639.find(current_user.language).try(:alpha2) || I18n.default_locale
+        I18n.locale = ISO_639.find(user.language).try(:alpha2) || I18n.default_locale
       rescue I18n::InvalidLocale
         I18n.locale = I18n.default_locale
       end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,10 @@ class SessionsController < Devise::SessionsController
   def create
     if Rails.env.development? or verify_recaptcha(model: resource)
       allow_params_authentication!
-      super
+      super do
+        set_locale
+        set_flash_message!(:notice, :signed_in)
+      end
     else
       self.resource = resource_class.new(sign_in_params)
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,12 @@ class UsersController < Devise::RegistrationsController
     end
   end
 
+  def update
+    super do |user|
+      set_locale(user)
+    end
+  end
+
   private
 
   def sign_up_params


### PR DESCRIPTION
Setting the locale in a `before_action` was too late for a couple scenarios:

* logging in
* updating language preference in one's account

But we can explicitly call `set_locale` at the right point for both of these cases
